### PR TITLE
Backport changes from freshly codebse

### DIFF
--- a/rspice/lib/rspice/shared_examples/a_class_pass_method.rb
+++ b/rspice/lib/rspice/shared_examples/a_class_pass_method.rb
@@ -1,36 +1,44 @@
 # frozen_string_literal: true
 
-# TODO: Jank - this should use Method#parameters, not Method#arity
-
 RSpec.shared_examples_for "a class pass method" do |method|
   subject do
-    if takes_options?
-      test_class.public_send(method, *arguments, **options)
+    if accepts_block?
+      test_class.public_send(method, *arguments, &block)
     else
       test_class.public_send(method, *arguments)
     end
   end
 
   let(:test_class) { described_class }
-  let(:initialize_arity) { test_class.instance_method(:initialize).arity }
-  let(:takes_options?) { (initialize_arity < 0) }
-  let(:argument_arity) { takes_options? ? (initialize_arity.abs - 1) : initialize_arity }
+
+  let(:method_parameters) { test_class.instance_method(:initialize).parameters }
+  let(:argument_arity) { method_parameters.map(&:first).select { |type| type.in?(%i[req opt]) }.length }
+  let(:option_keys) { method_parameters.select { |param| param.first.in?(%i[key keyreq]) }.map(&:last) }
+  let(:accepts_block?) { method_parameters.any? { |param| param.first == :block } }
 
   let(:arguments) do
-    Array.new(argument_arity) { double }
+    Array.new(argument_arity) { double }.tap do |array|
+      array << options if options.present?
+    end
   end
-  let(:options) { takes_options? ? Hash[*Faker::Lorem.words(2 * rand(1..2))].symbolize_keys : nil }
+  let(:options) { option_keys.each_with_object({}) { |key, hash| hash[key] = Faker::Lorem.word } }
+  let(:block) { -> {} }
   let(:instance) { instance_double(test_class) }
   let(:output) { double }
 
   before do
     allow(instance).to receive(method).and_return(output)
-    if takes_options?
-      allow(test_class).to receive(:new).with(*arguments, **options).and_return(instance)
+
+    if accepts_block?
+      allow(test_class).to receive(:new).with(*arguments, &block).and_return(instance)
     else
       allow(test_class).to receive(:new).with(*arguments).and_return(instance)
     end
   end
 
   it { is_expected.to eq output }
+
+  it "has matching parameters with initialize" do
+    expect(test_class.method(method).parameters).to eq test_class.instance_method(:initialize).parameters
+  end
 end

--- a/technologic/lib/technologic.rb
+++ b/technologic/lib/technologic.rb
@@ -66,9 +66,24 @@ module Technologic
     end
 
     EXCEPTION_SEVERITIES.each do |severity|
-      define_method("#{severity}!") do |error_class = StandardError, message = nil, **data, &block|
-        instrument severity, error_class.name.demodulize, **data, &block
-        raise error_class, message
+      define_method("#{severity}!") do |exception = StandardError, message = nil, **data, &block|
+        if exception.is_a?(Exception)
+          instrument(
+            severity,
+            exception.class.name.demodulize,
+            **{
+              message: exception.message,
+              additional_message: message,
+            }.compact,
+            **data,
+            &block
+          )
+
+          raise exception
+        else
+          instrument severity, exception.name.demodulize, message: message, **data, &block
+          raise exception, message
+        end
       end
     end
   end

--- a/technologic/spec/technologic_spec.rb
+++ b/technologic/spec/technologic_spec.rb
@@ -121,18 +121,60 @@ RSpec.describe Technologic do
     before { stub_const(modulized_error_class_name, example_error_class) }
   end
 
-  shared_examples_for "an exception severity method" do |described_method|
+  shared_examples_for "an exception severity method" do |severity|
     include_context "with instrumentation data"
-    include_context "with example error class"
 
-    subject(:example_method) { example_class.__send__(method_name, example_error_class, error_message, **data, &block) }
+    let(:message) { Faker::Lorem.sentence }
+    let(:module_name) { Faker::Internet.unique.domain_word.capitalize }
+    let(:error_class_name) { Faker::Internet.unique.domain_word.capitalize }
+    let(:modulized_error_class_name) { "#{module_name}::#{error_class_name}" }
+    let(:error_class) { modulized_error_class_name.constantize }
+    let(:expected_event_name) { "#{error_class_name}.#{event_namespace}.#{severity}" }
+    let(:example_error_class) { Class.new(StandardError) }
 
-    let(:severity) { described_method }
-    let(:method_name) { "#{severity}!" }
+    before { stub_const(modulized_error_class_name, example_error_class) }
 
-    it "raises and logs" do
-      expect { example_method }.to raise_error example_error_class, error_message
-      expect(ActiveSupport::Notifications).to have_received(:instrument).with(expected_event_name, **data, &block)
+    context "when an exception class is given" do
+      subject(:instrument!) { example_class.__send__("#{severity}!", error_class, message, **data, &block) }
+
+      it "raises and logs" do
+        expect { instrument! }.to raise_error example_error_class, message
+
+        expect(ActiveSupport::Notifications).
+          to have_received(:instrument).
+          with(expected_event_name, message: message, **data, &block)
+      end
+    end
+
+    context "when an exception instance is given" do
+      subject(:instrument!) do
+        example_class.__send__("#{severity}!", error_instance, **data, &block)
+      end
+
+      let(:error_instance) { example_error_class.new(message) }
+
+      it "raises and logs" do
+        expect { instrument! }.to raise_error error_instance
+
+        expect(ActiveSupport::Notifications).
+          to have_received(:instrument).
+          with(expected_event_name, message: message, **data, &block)
+      end
+
+      context "when another message is included in the #{severity}! call" do
+        subject(:instrument!) do
+          example_class.__send__("#{severity}!", error_instance, additional_message, **data, &block)
+        end
+
+        let(:additional_message) { Faker::ChuckNorris.fact }
+
+        it "includes the additional message in the log" do
+          expect { instrument! }.to raise_error error_instance
+          expect(ActiveSupport::Notifications).
+            to have_received(:instrument).
+            with(expected_event_name, message: message, additional_message: additional_message, **data, &block)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This allows `error!` and `fatal!` to accept exception instances - so if you're already in a rescue block, you can do this:
```ruby
rescue StandardError => exception=
  do_something_here
   fatal! exception
```