### PR TITLE
Fix superclass memoization

### DIFF
--- a/short_circu_it/lib/short_circu_it.rb
+++ b/short_circu_it/lib/short_circu_it.rb
@@ -26,11 +26,9 @@ module ShortCircuIt
 
   class_methods do
     def memoization_observers
-      if superclass.respond_to?(:memoization_observers)
-        superclass.memoization_observers.merge(_memoization_observers)
-      else
-        _memoization_observers
-      end
+      return _memoization_observers unless superclass.respond_to?(:memoization_observers)
+
+      superclass.memoization_observers.merge(_memoization_observers)
     end
 
     protected

--- a/short_circu_it/lib/short_circu_it.rb
+++ b/short_circu_it/lib/short_circu_it.rb
@@ -26,8 +26,11 @@ module ShortCircuIt
 
   class_methods do
     def memoization_observers
-      @memoization_observers ||=
-        superclass.respond_to?(:memoization_observers) ? superclass.memoization_observers : {}
+      if superclass.respond_to?(:memoization_observers)
+        superclass.memoization_observers.merge(_memoization_observers)
+      else
+        _memoization_observers
+      end
     end
 
     protected
@@ -87,11 +90,15 @@ module ShortCircuIt
 
     private
 
-    attr_writer :memoization_observers
+    attr_writer :_memoization_observers
+
+    def _memoization_observers
+      @_memoization_observers ||= {}
+    end
 
     def add_memoized_observers(method_name, observers)
       # TODO: Raise an error if method has already been memoized? A warning maybe?
-      self.memoization_observers = memoization_observers.
+      self._memoization_observers = _memoization_observers.
         merge(method_name.to_sym => Array.wrap(observers).freeze).
         freeze
     end

--- a/short_circu_it/spec/short_circu_it_spec.rb
+++ b/short_circu_it/spec/short_circu_it_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe ShortCircuIt do
       end
     end
 
-    shared_examples_for "memoization" do
+    shared_examples_for "a class with memoized methods" do
       context "when the method takes no arguments" do
         let(:memoized_method) { memoized_method_without_args }
 
@@ -352,13 +352,13 @@ RSpec.describe ShortCircuIt do
     context "when only one method is memoized at a time" do
       before { memoized_class.__send__(:memoize, memoized_method, **memoization_options) }
 
-      it_behaves_like "memoization"
+      it_behaves_like "a class with memoized methods"
     end
 
     context "when multiple methods are memoized at a time" do
       before { memoized_class.__send__(:memoize, *memoized_methods, **memoization_options) }
 
-      it_behaves_like "memoization"
+      it_behaves_like "a class with memoized methods"
     end
 
     context "when the method is memoized in the parent class after the child class is defined" do
@@ -373,7 +373,7 @@ RSpec.describe ShortCircuIt do
         memoized_class.__send__(:memoize, memoized_method, **memoization_options)
       end
 
-      it_behaves_like "memoization"
+      it_behaves_like "a class with memoized methods"
     end
   end
 end

--- a/short_circu_it/spec/short_circu_it_spec.rb
+++ b/short_circu_it/spec/short_circu_it_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe ShortCircuIt do
       end
     end
 
+    let(:memoized_method_with_args) { :method_with_arguments }
+    let(:memoized_method_without_args) { :method_without_arguments }
+    let(:memoized_methods) { [ memoized_method_with_args, memoized_method_without_args ] }
+
     let(:target_class) { base_class }
     let(:memoized_class) { base_class }
 
@@ -292,9 +296,6 @@ RSpec.describe ShortCircuIt do
     end
 
     shared_examples_for "memoization" do
-      let(:memoized_method_with_args) { :method_with_arguments }
-      let(:memoized_method_without_args) { :method_without_arguments }
-
       context "when the method takes no arguments" do
         let(:memoized_method) { memoized_method_without_args }
 
@@ -355,8 +356,6 @@ RSpec.describe ShortCircuIt do
     end
 
     context "when multiple methods are memoized at a time" do
-      let(:memoized_methods) { [ memoized_method_with_args, memoized_method_without_args ] }
-
       before { memoized_class.__send__(:memoize, *memoized_methods, **memoization_options) }
 
       it_behaves_like "memoization"

--- a/short_circu_it/spec/short_circu_it_spec.rb
+++ b/short_circu_it/spec/short_circu_it_spec.rb
@@ -44,11 +44,6 @@ RSpec.describe ShortCircuIt do
     let(:target_class) { base_class }
 
     let(:target_instance) { target_class.new }
-    let(:memoized_module) do
-      target_class.ancestors.find do |ancestor|
-        ancestor.is_a?(AroundTheWorld::ProxyModule) && ancestor.for?(described_class)
-      end
-    end
     let(:all_observer_methods) { %i[observed_value_one observed_value_two] }
 
     let(:target_change) { nil }
@@ -110,12 +105,6 @@ RSpec.describe ShortCircuIt do
       end
     end
 
-    shared_examples_for "it defines a memoization method" do
-      subject { memoized_module.instance_methods }
-
-      it { is_expected.to include memoized_method }
-    end
-
     shared_examples_for "a memoized value" do
       let!(:initial_value) { target_instance.public_send(memoized_method, *arguments) }
 
@@ -141,8 +130,6 @@ RSpec.describe ShortCircuIt do
     shared_examples_for "a method that observes nothing" do |with_memoization|
       include_context "when it observes nothing"
 
-      it_behaves_like "it defines a memoization method"
-
       context "when the instance does not change" do
         it_behaves_like(with_memoization ? "a memoized value" : "a new value")
       end
@@ -158,8 +145,6 @@ RSpec.describe ShortCircuIt do
       context "when the method observes one method" do
         include_context "when it observes one method"
 
-        it_behaves_like "it defines a memoization method"
-
         context "when the observed method does not change" do
           it_behaves_like(with_memoization ? "a memoized value" : "a new value")
         end
@@ -174,8 +159,6 @@ RSpec.describe ShortCircuIt do
     shared_examples_for "a method that observes self" do |with_memoization|
       include_context "when it observes itself"
 
-      it_behaves_like "it defines a memoization method"
-
       context "when the instance does not change" do
         it_behaves_like(with_memoization ? "a memoized value" : "a new value")
       end
@@ -188,8 +171,6 @@ RSpec.describe ShortCircuIt do
 
     shared_examples_for "a method that observes multiple methods" do |with_memoization|
       include_context "when it observes multiple methods"
-
-      it_behaves_like "it defines a memoization method"
 
       context "when neither observed method changes" do
         it_behaves_like(with_memoization ? "a memoized value" : "a new value")
@@ -253,8 +234,6 @@ RSpec.describe ShortCircuIt do
         context "when the method observes nothing" do
           include_context "when it observes nothing"
 
-          it_behaves_like "it defines a memoization method"
-
           context "when the instance does not change" do
             it_behaves_like "a new value"
           end
@@ -267,8 +246,6 @@ RSpec.describe ShortCircuIt do
 
         context "when the method observes self" do
           include_context "when it observes itself"
-
-          it_behaves_like "it defines a memoization method"
 
           context "when the instance does not change" do
             it_behaves_like "a new value"
@@ -283,8 +260,6 @@ RSpec.describe ShortCircuIt do
         context "when the method observes one method" do
           include_context "when it observes one method"
 
-          it_behaves_like "it defines a memoization method"
-
           context "when the observed method does not change" do
             it_behaves_like "a new value"
           end
@@ -297,8 +272,6 @@ RSpec.describe ShortCircuIt do
 
         context "when the method observes multiple methods" do
           include_context "when it observes multiple methods"
-
-          it_behaves_like "it defines a memoization method"
 
           context "when neither observed method changes" do
             it_behaves_like "a new value"

--- a/short_circu_it/spec/short_circu_it_spec.rb
+++ b/short_circu_it/spec/short_circu_it_spec.rb
@@ -207,7 +207,6 @@ RSpec.describe ShortCircuIt do
     end
 
     shared_examples_for "a method that takes no arguments" do |with_memoization: true|
-      let(:memoized_method) { memoized_method_without_args }
       let(:arguments) { [] }
 
       context "when the method observes nothing" do
@@ -228,7 +227,6 @@ RSpec.describe ShortCircuIt do
     end
 
     shared_examples_for "a method that takes arguments" do |with_memoization: true|
-      let(:memoized_method) { memoized_method_with_args }
       let(:arguments) { Array(rand(1..4)) { rand(100) } }
 
       context "when arguments do NOT change between calls" do
@@ -321,10 +319,14 @@ RSpec.describe ShortCircuIt do
 
     shared_examples_for "memoization" do
       context "when the method takes no arguments" do
+        let(:memoized_method) { memoized_method_without_args }
+
         it_behaves_like "a method that takes no arguments", with_memoization: true
       end
 
       context "when the method takes arguments" do
+        let(:memoized_method) { memoized_method_with_args }
+
         it_behaves_like "a method that takes arguments", with_memoization: true
       end
 
@@ -332,10 +334,14 @@ RSpec.describe ShortCircuIt do
         let(:memoized_class) { Class.new(base_class) }
 
         context "when the method takes no arguments" do
+          let(:memoized_method) { memoized_method_without_args }
+
           it_behaves_like "a method that takes no arguments", with_memoization: true
         end
 
         context "when the method takes arguments" do
+          let(:memoized_method) { memoized_method_with_args }
+
           it_behaves_like "a method that takes arguments", with_memoization: true
         end
 
@@ -351,10 +357,14 @@ RSpec.describe ShortCircuIt do
           end
 
           context "when the method takes no arguments" do
+            let(:memoized_method) { memoized_method_without_args }
+
             it_behaves_like "a method that takes no arguments", with_memoization: false
           end
 
           context "when the method takes arguments" do
+            let(:memoized_method) { memoized_method_with_args }
+
             it_behaves_like "a method that takes arguments", with_memoization: false
           end
         end


### PR DESCRIPTION
Here's a fun edge case for ya:

```ruby 
# a.rb
class A
  include ShortCircuIt

  def foo
    # important things happen!
  end
  memoize :foo
end

# b.rb
class B < A
  def bar
    # more important things!
  end
  memoize :bar
end

# initializers/a.rb
class A
  def baz!
    # moar thingsss
  end
  memoize :baz!
end

B.new.baz!
Traceback (most recent call last):
        7: from short_circu_it/bin/console:14:in `<main>'
        6: from (irb):21
        5: from /Users/allenrettberg/Documents/freshly/spicerack/short_circu_it/lib/short_circu_it.rb:81:in `block (2 levels) in memoize'
        4: from /Users/allenrettberg/Documents/freshly/spicerack/short_circu_it/lib/short_circu_it/memoization_store.rb:19:in `memoize'
        3: from /Users/allenrettberg/Documents/freshly/spicerack/short_circu_it/lib/short_circu_it/memoization_store.rb:59:in `memoized?'
        2: from /Users/allenrettberg/Documents/freshly/spicerack/short_circu_it/lib/short_circu_it/memoization_store.rb:80:in `current_memoization_for_method?'
        1: from /Users/allenrettberg/Documents/freshly/spicerack/short_circu_it/lib/short_circu_it/memoization_store.rb:86:in `state_hash'
NoMethodError (undefined method `map' for nil:NilClass)
```

This is because the child class is initializing its observers hash before `baz!` gets defined and memoized (see [here](https://github.com/Freshly/spicerack/blob/955a70ee31e2c27f4fe234a86b3185e84ac2bda7/short_circu_it/lib/short_circu_it.rb#L30)), so the observer for `baz!` never gets set on B. 

This PR addresses this issue by always including the superclass' memoization observers unless they get explicitly overriden in the child class
