### PR TITLE
Technologic: Remove Config Includes

### DIFF
--- a/technologic/lib/technologic/config_options.rb
+++ b/technologic/lib/technologic/config_options.rb
@@ -15,7 +15,5 @@ module Technologic
     class_attribute :log_warn_events, default: true
     class_attribute :log_info_events, default: true
     class_attribute :log_debug_events, default: true
-
-    class_attribute :include_in_classes, default: %w[ApplicationController]
   end
 end

--- a/technologic/lib/technologic/setup.rb
+++ b/technologic/lib/technologic/setup.rb
@@ -28,10 +28,6 @@ module Technologic
         Technologic::InfoSubscriber.on_event { |e| Technologic::Logger.log(:info, e) } if config.log_info_events
         Technologic::DebugSubscriber.on_event { |e| Technologic::Logger.log(:debug, e) } if config.log_debug_events
       end
-
-      def setup_includes(config)
-        config.include_in_classes.each { |class_name| class_name.constantize.include(Technologic) }
-      end
     end
   end
 end

--- a/technologic/spec/technologic/config_options_spec.rb
+++ b/technologic/spec/technologic/config_options_spec.rb
@@ -57,8 +57,4 @@ RSpec.describe Technologic::ConfigOptions do
   describe ".log_debug_events" do
     it_behaves_like "a config option", :log_debug_events
   end
-
-  describe ".include_in_classes" do
-    it_behaves_like "a config option", :include_in_classes, %w[ApplicationController]
-  end
 end

--- a/technologic/spec/technologic/setup_spec.rb
+++ b/technologic/spec/technologic/setup_spec.rb
@@ -133,32 +133,4 @@ RSpec.describe Technologic::Setup do
     it_behaves_like "a subscription event listener", :info
     it_behaves_like "a subscription event listener", :debug
   end
-
-  describe ".setup_includes" do
-    subject(:setup_includes) { described_class.__send__(:setup_includes, config) }
-
-    before { allow(config).to receive(:include_in_classes).and_return(include_in_classes) }
-
-    context "when there are none classes" do
-      let(:include_in_classes) { [] }
-
-      it "does not raise an error" do
-        expect { include_in_classes }.not_to raise_error
-      end
-    end
-
-    context "with a valid class" do
-      let(:include_in_classes) { [ example_class_name ] }
-
-      let(:example_class) { Class.new }
-      let(:example_class_name) { Faker::Internet.domain_word.capitalize }
-
-      before { stub_const(example_class_name, example_class) }
-
-      it "includes the modules" do
-        expect { setup_includes }.to(change { example_class.included_modules })
-        expect(example_class.included_modules).to include Technologic
-      end
-    end
-  end
 end


### PR DESCRIPTION
These were an aspirational thing that didn't pan out. Used to get wildly
annoying issues with the server losing logging behavior when editing any
of the classes in the include list.

Since it's saving all of four or five lines of code, and is basically
just moving this Gem's implementation into a junk drawer, I'm killin it.