### PR TITLE
RSpice: Fix inherit_from

### DIFF
--- a/rspice/lib/rspice/custom_matchers/extend_module.rb
+++ b/rspice/lib/rspice/custom_matchers/extend_module.rb
@@ -11,21 +11,10 @@
 # end
 
 RSpec::Matchers.define :extend_module do |module_class|
-  match do
-    test_subject.singleton_class.included_modules.include? module_class
-  end
-
-  description do
-    "extended the module #{module_class}"
-  end
-
-  failure_message do |described_class|
-    "expected #{described_class} to extend module #{module_class}"
-  end
-
-  failure_message_when_negated do |described_class|
-    "expected #{described_class} not to extend module #{module_class}"
-  end
+  match { test_subject.singleton_class.included_modules.include? module_class }
+  description { "extended the module #{module_class}" }
+  failure_message { |described_class| "expected #{described_class} to extend module #{module_class}" }
+  failure_message_when_negated { |described_class| "expected #{described_class} not to extend module #{module_class}" }
 
   def test_subject
     subject.is_a?(Class) ? subject : subject.class

--- a/rspice/lib/rspice/custom_matchers/include_module.rb
+++ b/rspice/lib/rspice/custom_matchers/include_module.rb
@@ -11,21 +11,10 @@
 # end
 
 RSpec::Matchers.define :include_module do |module_class|
-  match do
-    test_subject.included_modules.include? module_class
-  end
-
-  description do
-    "included the module #{module_class}"
-  end
-
-  failure_message do |described_class|
-    "expected #{described_class} to include module #{module_class}"
-  end
-
-  failure_message_when_negated do |described_class|
-    "expected #{described_class} not to include module #{module_class}"
-  end
+  match { test_subject.included_modules.include? module_class }
+  description { "included the module #{module_class}" }
+  failure_message { |described_class| "expected #{described_class} to include module #{module_class}" }
+  failure_message_when_negated { |described_class| "expected #{described_class} not to include module #{module_class}" }
 
   def test_subject
     subject.is_a?(Class) ? subject : subject.class

--- a/rspice/lib/rspice/custom_matchers/inherit_from.rb
+++ b/rspice/lib/rspice/custom_matchers/inherit_from.rb
@@ -11,19 +11,12 @@
 # end
 
 RSpec::Matchers.define :inherit_from do |superclass|
-  match do
-    described_class.ancestors.include? superclass
-  end
+  match { test_subject.ancestors.include? superclass }
+  description { "inherit from #{superclass}" }
+  failure_message { "expected #{described_class.name} to inherit from #{superclass}" }
+  failure_message_when_negated { "expected #{described_class.name} not to inherit from #{superclass}" }
 
-  description do
-    "inherit from #{superclass}"
-  end
-
-  failure_message do
-    "expected #{described_class.name} to inherit from #{superclass}"
-  end
-
-  failure_message_when_negated do
-    "expected #{described_class.name} not to inherit from #{superclass}"
+  def test_subject
+    subject.is_a?(Class) ? subject : subject.class
   end
 end


### PR DESCRIPTION
Was using the old janky style of matcher.

Syntax cleaned up the other module tree helpers as well.