### PR TITLE
BL-638 Fix Faker deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       activesupport (~> 5.2.1)
       redis (>= 3.0)
     rspice (0.14.2)
-      faker (~> 1.8)
+      faker (~> 2.0)
       rspec (~> 3.0)
     short_circu_it (0.14.2)
       activesupport (~> 5.2.1)
@@ -61,7 +61,7 @@ GEM
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.8.0)
-    faker (1.9.3)
+    faker (2.0)
       i18n (>= 0.7)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -145,7 +145,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0.1)
-  faker (~> 1.8)
+  faker (~> 2.0)
   pry (~> 0.10.0)
   pry-nav (>= 0.2.4)
   rake (~> 10.0)

--- a/rspice/rspice.gemspec
+++ b/rspice/rspice.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = "lib"
 
   spec.add_dependency "rspec", "~> 3.0"
-  spec.add_dependency "faker", "~> 1.8"
+  spec.add_dependency "faker", "~> 2.0"
 end

--- a/spicerack.gemspec
+++ b/spicerack.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.16"
-  spec.add_development_dependency "faker", "~> 1.8"
+  spec.add_development_dependency "faker", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.10.0"
   spec.add_development_dependency "pry-nav", ">= 0.2.4"
   spec.add_development_dependency "shoulda-matchers", "4.0.1"


### PR DESCRIPTION
# WORK IN PROGRESS

Changing this gem seems like it's going to be painful.

https://freshly.atlassian.net/browse/BL-638
https://freshly.atlassian.net/browse/BL-639
https://freshly.atlassian.net/browse/BL-640

To fix this:

<img width="1336" alt="Screen Shot 2019-07-31 at 11 40 02 AM" src="https://user-images.githubusercontent.com/5471958/62226382-23429100-b388-11e9-8b00-9adc526ae03d.png">

I need this:

<img width="512" alt="Screen Shot 2019-07-31 at 11 38 50 AM" src="https://user-images.githubusercontent.com/5471958/62226400-2a699f00-b388-11e9-8adc-a0388496147c.png">
