### PR TITLE
Require blank from active support to make "#present?" work

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,6 +14,7 @@ jobs:
         ruby-version: 2.5.x
     - name: Set up dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libsqlite3-dev
         sudo apt-get install redis-server
         gem install bundler
@@ -37,6 +38,7 @@ jobs:
         ruby-version: 2.5.x
     - name: Set up dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libsqlite3-dev
         sudo apt-get install redis-server
         gem install bundler
@@ -61,6 +63,7 @@ jobs:
         ruby-version: 2.6.x
     - name: Set up dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libsqlite3-dev
         sudo apt-get install redis-server
         gem install bundler
@@ -84,6 +87,7 @@ jobs:
         ruby-version: 2.6.x
     - name: Set up dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libsqlite3-dev
         sudo apt-get install redis-server
         gem install bundler

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,6 @@
 name: RSpec
 
-on: [push]
+on: push
 
 jobs:
   ruby_2_5_rails_5_2:

--- a/around_the_world/lib/around_the_world.rb
+++ b/around_the_world/lib/around_the_world.rb
@@ -5,6 +5,7 @@ require_relative "around_the_world/method_wrapper"
 require_relative "around_the_world/proxy_module"
 require_relative "around_the_world/version"
 require "active_support/concern"
+require "active_support/core_ext/object/blank"
 require "active_support/descendants_tracker"
 
 module AroundTheWorld


### PR DESCRIPTION
AroundTheWorld uses `present?` in some places, it was raising when `nil.present?` was called when testing it in `irb`.

This ALSO fixes the github actions that run rspec in different versions of Ruby. Needed to run `sudo apt-get update` to update the package list before installing the packages because it was unable to find some.