### PR TITLE
Rubocop updates: Disable Lint/MissingSuper and RSpec/MultipleMemoizedHelpers checks

### DIFF
--- a/spicerack-styleguide/rubocop.yml
+++ b/spicerack-styleguide/rubocop.yml
@@ -331,7 +331,7 @@ Lint/Loop:
 Lint/MissingCopEnableDirective:
   Enabled: true
 Lint/MissingSuper:
-  Enabled: true
+  Enabled: false
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 Lint/MultipleComparison:
@@ -1471,7 +1471,7 @@ RSpec/MultipleDescribes:
 RSpec/MultipleExpectations:
   Enabled: false
 RSpec/MultipleMemoizedHelpers:
-    Enabled: true
+    Enabled: false
 RSpec/MultipleSubjects:
   Enabled: true
 RSpec/NamedSubject:


### PR DESCRIPTION
*What this PR does?*

1. disables `Lint/MissingSuper` check https://docs.rubocop.org/rubocop/cops_lint.html#lintmissingsuper
2. disables `RSpec/MultipleMemoizedHelpers` check https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmultiplememoizedhelpers