### PR TITLE
ARCH-2109 ensure errors.messages doesn't raise in have_error_on_attribute matcher

### DIFF
--- a/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
+++ b/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
@@ -26,7 +26,7 @@ RSpec::Matchers.define :have_error_on_attribute do |attribute|
     @errors = (record.errors.details[attribute.to_sym] || []).pluck(:error).map(&:to_sym)
 
     expect(@errors).to include(@detail_key.to_sym)
-    expect(record.errors.messages).to_not raise_error(I18n::MissingTranslationData)
+    expect(record.errors[attribute]).to_not raise_error(I18n::MissingTranslationData)
   end
 
   chain :with_detail_key do |detail_key|

--- a/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
+++ b/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
@@ -26,7 +26,7 @@ RSpec::Matchers.define :have_error_on_attribute do |attribute|
     @errors = (record.errors.details[attribute.to_sym] || []).pluck(:error).map(&:to_sym)
 
     expect(@errors).to include(@detail_key.to_sym)
-    expect(record.errors[attribute.to_sym]).to_not raise_error(I18n::MissingTranslationData)
+    expect(record.errors[attribute.to_sym]).to_not raise_error
   end
 
   chain :with_detail_key do |detail_key|

--- a/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
+++ b/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
@@ -26,7 +26,7 @@ RSpec::Matchers.define :have_error_on_attribute do |attribute|
     @errors = (record.errors.details[attribute.to_sym] || []).pluck(:error).map(&:to_sym)
 
     expect(@errors).to include(@detail_key.to_sym)
-    expect(record.errors[attribute]).to_not raise_error(I18n::MissingTranslationData)
+    expect(record.errors[attribute.to_sym]).to_not raise_error(I18n::MissingTranslationData)
   end
 
   chain :with_detail_key do |detail_key|

--- a/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
+++ b/rspice/lib/rspice/custom_matchers/have_error_on_attribute.rb
@@ -26,6 +26,7 @@ RSpec::Matchers.define :have_error_on_attribute do |attribute|
     @errors = (record.errors.details[attribute.to_sym] || []).pluck(:error).map(&:to_sym)
 
     expect(@errors).to include(@detail_key.to_sym)
+    expect(record.errors.messages).to_not raise_error(I18n::MissingTranslationData)
   end
 
   chain :with_detail_key do |detail_key|


### PR DESCRIPTION
https://freshly.atlassian.net/browse/ARCH-2109

To test  : 
Use referral service branch: `ARCH-2019-rraise-on-missing-i18n-translations-in-development`,  and run the specs . They should be all green .

update `spicerack` line in Gemfile to following : 
`  gem "spicerack", git: "git@github.com:Freshly/spicerack.git", branch: "ARCH-2109-assert-have-error-on-attribute-matcher-doesnt-raise"`

run `bundle install`

run the rspecs, you should have a failure for a missing translation : 
```ruby
  1) CreateExtoleReferralState Validations #identity_token_present? when the referrer does not have an identity_token behaves like an invalid state returns the correct error message
     Failure/Error: expect(state).to have_error_on_attribute(attribute).with_detail_key(expected_key)

     I18n::MissingTranslationData:
       translation missing: en.activemodel.errors.models.create_extole_referral_state.attributes.identity_token.referrer_must_have_identity_token
```