### PR TITLE
Do not raise NotValidatedError if Output is also Argument or Option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       rubocop-ast (>= 0.5.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.10.0)
+    rubocop-ast (1.11.0)
       parser (>= 3.0.1.1)
     rubocop-performance (1.8.1)
       rubocop (>= 0.87.0)

--- a/substance/lib/substance/objects/output.rb
+++ b/substance/lib/substance/objects/output.rb
@@ -39,7 +39,8 @@ module Substance
 
         def ensure_validation_before(method)
           around_method method do |*args, **opts|
-            raise NotValidatedError unless validated?
+            attr_name = method.to_s.delete("=").to_sym
+            raise NotValidatedError unless validated? || _options.include?(attr_name) || _arguments.include?(attr_name)
 
             # TODO: replace with `super(...)` when <= 2.6 support is dropped
             if RUBY_VERSION < "2.7" && opts.blank?

--- a/substance/lib/substance/objects/output.rb
+++ b/substance/lib/substance/objects/output.rb
@@ -62,9 +62,11 @@ module Substance
       end
 
       def validated_output?(method)
-        attr_name = method.to_s.delete("=").to_sym
+        validate? || begin
+          attr_name = method.to_s.delete("=").to_sym
 
-        validated? || _options.include?(attr_name) || _arguments.include?(attr_name)
+          _options.include?(attr_name) || _arguments.include?(attr_name)
+        end
       end
     end
   end

--- a/substance/lib/substance/objects/output.rb
+++ b/substance/lib/substance/objects/output.rb
@@ -39,7 +39,6 @@ module Substance
 
         def ensure_validation_before(method)
           around_method method do |*args, **opts|
-            attr_name = method.to_s.delete("=").to_sym
             raise NotValidatedError unless validated_output?(method)
 
             # TODO: replace with `super(...)` when <= 2.6 support is dropped
@@ -61,8 +60,6 @@ module Substance
       def output_struct
         Struct.new(*_outputs)
       end
-
-      private
 
       def validated_output?(method)
         attr_name = method.to_s.delete("=").to_sym

--- a/substance/lib/substance/objects/output.rb
+++ b/substance/lib/substance/objects/output.rb
@@ -40,7 +40,7 @@ module Substance
         def ensure_validation_before(method)
           around_method method do |*args, **opts|
             attr_name = method.to_s.delete("=").to_sym
-            raise NotValidatedError unless validated? || _options.include?(attr_name) || _arguments.include?(attr_name)
+            raise NotValidatedError unless validated_output?(method)
 
             # TODO: replace with `super(...)` when <= 2.6 support is dropped
             if RUBY_VERSION < "2.7" && opts.blank?
@@ -60,6 +60,14 @@ module Substance
 
       def output_struct
         Struct.new(*_outputs)
+      end
+
+      private
+
+      def validated_output?(method)
+        attr_name = method.to_s.delete("=").to_sym
+
+        validated? || _options.include?(attr_name) || _arguments.include?(attr_name)
       end
     end
   end

--- a/substance/lib/substance/objects/output.rb
+++ b/substance/lib/substance/objects/output.rb
@@ -62,7 +62,7 @@ module Substance
       end
 
       def validated_output?(method)
-        validate? || begin
+        validated? || begin
           attr_name = method.to_s.delete("=").to_sym
 
           _options.include?(attr_name) || _arguments.include?(attr_name)

--- a/substance/spec/substance/objects/output_spec.rb
+++ b/substance/spec/substance/objects/output_spec.rb
@@ -103,20 +103,53 @@ RSpec.describe Substance::Objects::Output, type: :concern do
     context "with outputs" do
       include_context "with example state having output"
 
-      context "without running validations" do
-        it "raises" do
-          expect { example_output_object.outputs }.to raise_error Substance::NotValidatedError
+      context "when not validated" do
+        context "when outputs are NOT arguments or options" do
+          it "raises" do
+            expect { example_output_object.outputs }.to raise_error Substance::NotValidatedError
+          end
+        end
+
+        context "when outputs are also arguments" do
+          let(:example_output_object) { example_class.new(state_input) }
+          let(:state_input) do
+            { test_output0: nil, test_output1: :default_value1, test_output2: :default_value2 }
+          end
+
+          let(:expected_outputs) { state_input }
+
+          before do
+            example_class.__send__(:argument, :test_output0)
+            example_class.__send__(:argument, :test_output1)
+            example_class.__send__(:argument, :test_output2)
+          end
+
+          it { is_expected.to have_attributes(**expected_outputs) }
+        end
+
+        context "when outputs are also options" do
+          let(:expected_outputs) do
+            { test_output0: :option_default_value0, test_output1: :option_default_value1, test_output2: nil }
+          end
+
+          before do
+            example_class.__send__(:option, :test_output0, default: :option_default_value0)
+            example_class.__send__(:option, :test_output1, default: :option_default_value1)
+            example_class.__send__(:option, :test_output2)
+          end
+
+          it { is_expected.to have_attributes(**expected_outputs) }
         end
       end
 
-      context "when valid" do
-        let(:expected_hash) do
+      context "when validated" do
+        let(:expected_outputs) do
           { test_output0: nil, test_output1: :default_value1, test_output2: :default_value2 }
         end
 
         before { example_output_object.valid? }
 
-        it { is_expected.to have_attributes(**expected_hash) }
+        it { is_expected.to have_attributes(**expected_outputs) }
       end
     end
   end

--- a/substance/spec/substance/objects/output_spec.rb
+++ b/substance/spec/substance/objects/output_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Substance::Objects::Output, type: :concern do
         end
 
         context "when outputs are also arguments" do
-          let(:example_output_object) { example_class.new(state_input) }
+          let(:example_output_object) { example_class.new(**state_input) }
           let(:state_input) do
             { test_output0: nil, test_output1: :default_value1, test_output2: :default_value2 }
           end


### PR DESCRIPTION
Fixes bug that raises NotValidatedError on Outputs that are also Arguments or Options.